### PR TITLE
Lint HTML fragments

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,3 +21,21 @@ class HtmlTidy(Linter):
     cmd = 'tidy -errors -quiet -utf8'
     regex = r'^line (?P<line>\d+) column (?P<col>\d+) - (?:(?P<error>Error)|(?P<warning>Warning)): (?P<message>.+)'
     error_stream = util.STREAM_STDERR
+
+    def communicate(self, cmd, code=''):
+        """
+        If the code that is linted is an HTML fragment, 
+        we wrap it into a valid HTML document.
+        """
+        if code.find('<html') == -1 and code.find('<body') == -1:
+            code = \
+                ("<!DOCTYPE html><html><head><title>Fragment</title></head><body>" + \
+                "%s" + \
+                "</body></html>") \
+                % code
+
+        return util.communicate(
+            cmd,
+            code,
+            output_stream=self.error_stream,
+            env=self.env)


### PR DESCRIPTION
As I develop with angular, I have some javascript templates that are HTML files and that I would want to lint with tidy. However these files are HTML fragments, i.e. they don't contain `html`or `body` tags. In order for tidy to successfully lint these files, I wrap them into a valid HTML document.
