### PR TITLE
Added tab_width to linter.py

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,3 +21,4 @@ class HtmlTidy(Linter):
     cmd = 'tidy -errors -quiet -utf8'
     regex = r'^line (?P<line>\d+) column (?P<col>\d+) - (?:(?P<error>Error)|(?P<warning>Warning)): (?P<message>.+)'
     error_stream = util.STREAM_STDERR
+    tab_width = 8


### PR DESCRIPTION
I think tab_width should be specified as the default for more linters.
Is there a reason tab_width isn't specified more often?

Considering that SublimeLinter already parses the reported visual column number to a character column number, it makes sense to me to set the tab_width to the default of the linter itself.
This way, regardless of a person's tab settings the regions should be in the same position. (Only if they change the linter's tab_size setting would it misalign)

Here's an example of it without tab_width where the regions should only be marking the '<'s:
![Example of mis-aligned regions](http://i.imgur.com/OZxy7rb.png)

After setting tab_width it works fine.
