### PR TITLE
Added instructions to install tidy-html5 for Mac OS X with brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,11 @@ SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 
 ### Linter installation
 Before installing this plugin, you must ensure that `tidy` is installed on your system.
 
-- **Mac OS X** – `tidy` comes preinstalled on recent versions of Mac OS X. You can install a more recent version by using [Homebrew](http://brew.sh) and `brew install homebrew/dupes/tidy`.
+- **Mac OS X** – `tidy` comes preinstalled on recent versions of Mac OS X. You can install a more recent stable version by using [Homebrew](http://brew.sh) and `brew install homebrew/dupes/tidy`. For the experimental html5 version  you can instead use `brew install homebrew/dupes/tidy --HEAD` or build it from [source](https://github.com/w3c/tidy-html5).
 
-- **Linux** – You should be able to install tidy using the system’s package manager. For example, on Debian-based systems (including Ubuntu), you can install with `sudo apt-get install tidy`.
+- **Linux** – You should be able to install tidy using the system’s package manager. For example, on Debian-based systems (including Ubuntu), you can install with `sudo apt-get install tidy`. The experimental [html5](https://github.com/w3c/tidy-html5) version can be built and installed from source.
 
-- **Windows** – A Windows binary is available [here](http://www.paehl.com/open_source/?HTML_Tidy_for_Windows).
-
-On Mac OS X and Linux, you can also try building the experimental [html5 tidy](https://github.com/w3c/tidy-html5). A Windows binary with HTML5 support is available [here](http://tidybatchfiles.info/).
+- **Windows** – Windows binaries are available for both the [stable](http://www.paehl.com/open_source/?HTML_Tidy_for_Windows) version, and the experimental [html5](http://tidybatchfiles.info/).
 
 ### Linter configuration
 In order for `tidy` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.


### PR DESCRIPTION
tidy-html5 can be installed with mac homebrew as tidy 
using `brew install homebrew/dupes/tidy --HEAD`