### PR TITLE
get tidy5 binary always

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -11,7 +11,6 @@
 """This module exports the HtmlTidy plugin class."""
 
 from SublimeLinter.lint import Linter, util
-import shutil
 
 
 class HtmlTidy(Linter):
@@ -19,7 +18,7 @@ class HtmlTidy(Linter):
     """Provides an interface to tidy."""
 
     syntax = 'html'
-    if shutil.which('tidy5'):
+    if Linter.which('tidy5'):
         cmd = 'tidy5 -errors -quiet -utf8'
     else:
         cmd = 'tidy -errors -quiet -utf8'


### PR DESCRIPTION
Check path of tidy5 binary with Linter classmethod `which`:
http://www.sublimelinter.com/en/latest/linter_methods.html?highlight=executable_path#which

Fixes https://github.com/SublimeLinter/SublimeLinter-html-tidy/issues/31