### PR TITLE
Re-submit fix #33 version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --add-ignore=D202

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --add-ignore=D202
+  - pep257 . --add-ignore=D202,D211

--- a/linter.py
+++ b/linter.py
@@ -14,6 +14,7 @@ from SublimeLinter.lint import Linter, util
 
 
 class HtmlTidy(Linter):
+    
     """Provides an interface to tidy."""
 
     syntax = 'html'

--- a/linter.py
+++ b/linter.py
@@ -18,9 +18,18 @@ class HtmlTidy(Linter):
     """Provides an interface to tidy."""
 
     syntax = 'html'
-    if Linter.which('tidy5'):
-        cmd = 'tidy5 -errors -quiet -utf8'
-    else:
-        cmd = 'tidy -errors -quiet -utf8'
+    executable = 'tidy'
+    version_args = '--version'
+    version_re = r'(?P<version>\d+\.\d+\.\d+)'
+    version_requirement = '>= 4.9'
     regex = r'^line (?P<line>\d+) column (?P<col>\d+) - (?:(?P<error>Error)|(?P<warning>Warning)): (?P<message>.+)'
     error_stream = util.STREAM_STDERR
+
+    def cmd(self):
+        """Return a tuple with the command line to execute."""
+        command = [self.executable_path, '-errors', '-quiet', '-utf8']
+        if Linter.which('tidy5'):
+            command[0] = Linter.which('tidy5')
+        else:
+            command[0] = Linter.which('tidy')
+        return command

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,6 @@ from SublimeLinter.lint import Linter, util
 
 
 class HtmlTidy(Linter):
-
     """Provides an interface to tidy."""
 
     syntax = 'html'

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,7 @@ from SublimeLinter.lint import Linter, util
 
 
 class HtmlTidy(Linter):
-    
+
     """Provides an interface to tidy."""
 
     syntax = 'html'


### PR DESCRIPTION
As ian4hu pointed out in [#33](https://github.com/SublimeLinter/SublimeLinter-html-tidy/pull/SublimeLinter#33), Linter.which() called from within the HtmlTidy class definition resulted in an early invocation situation in which a fail test resulted for Linter's settings, _paths_ in particular, prior to any setting being cached.
Changes to fix this.
