### PR TITLE
Fixup for SublimeLinter 4

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,18 +18,12 @@ class HtmlTidy(Linter):
     """Provides an interface to tidy."""
 
     syntax = 'html'
-    executable = 'tidy'
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 4.9'
     regex = r'^line (?P<line>\d+) column (?P<col>\d+) - (?:(?P<error>Error)|(?P<warning>Warning)): (?P<message>.+)'
     error_stream = util.STREAM_STDERR
 
     def cmd(self):
         """Return a tuple with the command line to execute."""
-        command = [self.executable_path, '-errors', '-quiet', '-utf8']
-        if Linter.which('tidy5'):
-            command[0] = Linter.which('tidy5')
-        else:
-            command[0] = Linter.which('tidy')
-        return command
+        # Must return either a full path to a binary or an informal name
+        # of an executable.
+        executable = self.which('tidy5') or 'tidy'
+        return [executable, '-errors', '-quiet', '-utf8']


### PR DESCRIPTION
Notable: Must ensure that cmd[0] as returned by `cmd()` is never 'falsy'.

Fixes https://github.com/SublimeLinter/SublimeLinter/issues/1215